### PR TITLE
Control item selection state in vaadin-nav

### DIFF
--- a/test/items.html
+++ b/test/items.html
@@ -86,21 +86,6 @@
           expect(item.getAttribute('focus-ring')).to.equal('');
         });
 
-        it('should be selectable with mouse click', () => {
-          item.click();
-          expect(item.selected).to.be.true;
-        });
-
-        it('should be selectable with Enter key', () => {
-          enter(item);
-          expect(item.selected).to.be.true;
-        });
-
-        it('should be selectable with Space key', () => {
-          space(item);
-          expect(item.selected).to.be.true;
-        });
-
         it('should have aria-disabled when disabled', () => {
           item.disabled = true;
           expect(item.getAttribute('aria-disabled')).to.equal('true');

--- a/vaadin-nav-item-mixin.html
+++ b/vaadin-nav-item-mixin.html
@@ -50,13 +50,11 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('mouseup', e => this._setActive(this._mousedown = false));
       this.addEventListener('keydown', e => this._onKeydown(e));
       this.addEventListener('keyup', e => this._onKeyup(e));
-      this.addEventListener('click', e => this._toggle());
+      this.addEventListener('click', e => this._select());
     }
 
-    _toggle() {
-      this.selected = !this.selected;
-      const evt = new CustomEvent('selected', {bubbles: true, cancelable: true, composed: true, detail: this.selected});
-      this.dispatchEvent(evt);
+    _select() {
+      this.dispatchEvent(new CustomEvent('select', {bubbles: true}));
     }
 
     _selectedChanged(selected) {
@@ -103,7 +101,7 @@ This program is available under Apache License Version 2.0, available at https:/
     _onKeyup(event) {
       if (/^( |SpaceBar|Enter)$/.test(event.key)) {
         this._setActive(false);
-        this._toggle();
+        this._select();
       }
     }
   };

--- a/vaadin-nav-list-mixin.html
+++ b/vaadin-nav-list-mixin.html
@@ -39,7 +39,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     ready() {
       super.ready();
-      this.addEventListener('selected', e => this._onSelected(e));
+      this.addEventListener('select', e => this._onSelect(e));
       this.addEventListener('keydown', e => this._onKeydown(e));
 
       this._selectedChanged(this.selected);
@@ -130,13 +130,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    _onSelected(e) {
-      if (!e.detail) {
-        // Prevent the user to unselect the current item
-        e.target.selected = true;
-      } else {
-        this.selected = this._navItems.indexOf(e.target);
-      }
+    _onSelect(e) {
+      this.selected = this._navItems.indexOf(e.target);
+      e.stopImmediatePropagation();
     }
   };
 </script>


### PR DESCRIPTION
Connects to #3

`<vaadin-nav>` already fully controls item selection states in `_selectedChanged`. Removed redundant logic. -6LOC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-nav/6)
<!-- Reviewable:end -->
