### PR TITLE
Remove focused state on focusout event

### DIFF
--- a/test/nav.html
+++ b/test/nav.html
@@ -182,6 +182,13 @@
           keyDownChar(nav, 'b');
           expect(nav._navItems[1].focused).to.be.true;
         });
+
+        it('should loose focused state on focusout event', () => {
+          nav._navItems[0].dispatchEvent(new CustomEvent('focus', {composed: true, bubbles: true}));
+          expect(nav._navItems[0].hasAttribute('focused')).to.be.true;
+          nav._navItems[0].dispatchEvent(new CustomEvent('focusout', {composed: true, bubbles: true}));
+          expect(nav._navItems[0].hasAttribute('focused')).to.be.false;
+        });
       });
     });
   </script>

--- a/vaadin-nav-item-mixin.html
+++ b/vaadin-nav-item-mixin.html
@@ -46,7 +46,6 @@ This program is available under Apache License Version 2.0, available at https:/
         this._setFocused(true);
       }, true);
       this.addEventListener('focusout', e => this._setFocused(false));
-      this.addEventListener('blur', e => this._setFocused(false), true);
       this.addEventListener('mousedown', e => this._setActive(this._mousedown = true));
       this.addEventListener('mouseup', e => this._setActive(this._mousedown = false));
       this.addEventListener('keydown', e => this._onKeydown(e));

--- a/vaadin-nav-item-mixin.html
+++ b/vaadin-nav-item-mixin.html
@@ -45,6 +45,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('focus', e => {
         this._setFocused(true);
       }, true);
+      this.addEventListener('focusout', e => this._setFocused(false));
       this.addEventListener('blur', e => this._setFocused(false), true);
       this.addEventListener('mousedown', e => this._setActive(this._mousedown = true));
       this.addEventListener('mouseup', e => this._setActive(this._mousedown = false));


### PR DESCRIPTION
Connects to #3 

Remove `focused` state on `focusout` event

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-nav/15)
<!-- Reviewable:end -->
